### PR TITLE
Putting bellows back on the main zigpy version that works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-git+git://github.com/rcloran/bellows.git#egg=bellows
+bellows==0.7.0
+


### PR DESCRIPTION
Noticed some issues with the fork of bellows used (syntax problems, etc).  That fork was many commits behind so I used the head repo from zigpy and hue-thief worked with that dependency no problem.