### PR TITLE
Bump bellows 0.7.0 -> 0.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bellows==0.7.0
+bellows==0.16.0
 


### PR DESCRIPTION
After updating the firmware on my EZSP device, I started to receive an error within the `bellows` dependency when running hue-thief. This did not happen prior to the firmware upgrade. I couldn't retain the exact trace but it appears similar to the following:
```
Exception in callback SerialTransport._read_ready()
handle: <Handle SerialTransport._read_ready()>
Traceback (most recent call last):
  File "/usr/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/srv/homeassistant/lib/python3.7/site-packages/serial_asyncio/__init__.py", line 106, in _read_ready
    self._protocol.data_received(data)
  File "/srv/homeassistant/lib/python3.7/site-packages/bellows/uart.py", line 64, in data_received
    self.frame_received(frame)
  File "/srv/homeassistant/lib/python3.7/site-packages/bellows/uart.py", line 86, in frame_received
    self.data_frame_received(data)
  File "/srv/homeassistant/lib/python3.7/site-packages/bellows/uart.py", line 107, in data_frame_received
    self._application.frame_received(self._randomize(data[1:-3]))
  File "/srv/homeassistant/lib/python3.7/site-packages/bellows/ezsp.py", line 170, in frame_received
    assert expected_id == frame_id
AssertionError
```

Bumping bellows to the current `0.16.0` version resolves this problem without any other changes.