### PR TITLE
chore: update README to indicate pairing required

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ pip3 install --user -r requirements.txt
 
 ## Usage
 
-Bring the bulb(s) you want to factory reset close to your EZSP device. Shutdown any other applications (home assistant, perhaps?) that may be using the EZSP device. Power on the bulb(s) and immediately:
+Make sure the bulb(s) are paired with the Hue Bridge when you start. Bring the bulb(s) you want to factory reset close to your EZSP device. Shutdown any other applications (home assistant, perhaps?) that may be using the EZSP device. Power on the bulb(s) and immediately:
 
 ```sh
 python3 hue-thief /dev/ttyUSB0


### PR DESCRIPTION
This PR just makes it clear in the instructions that the bulb(s) should be paired with the Hue Bridge when you attempt to free them from the Hue Bridge.

When I used this, I wasted a ton of time attempting to use it, but it wouldn't work until I made sure to pair them with the Hue Bridge before scanning for them.  I'm hoping that a simple change to there README.markdown will make it easier on others.

Thanks for making this awesome tool! 🥂 
