### PR TITLE
Add optional baudrate parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,10 @@ Bring the bulb(s) you want to factory reset close to your EZSP device. Shutdown 
 ```sh
 python3 hue-thief /dev/ttyUSB0
 ```
+or if you need to change the baudrate to 115200 for the Home Assistant SkyConnect:
+```sh
+python3 hue-thief /dev/ttyUSB0 --baudrate 115200
+```
 
 `/dev/ttyUSB0` should be your EZSP device. You should have full permissions on this device file.
 

--- a/hue-thief.py
+++ b/hue-thief.py
@@ -2,6 +2,7 @@ import asyncio
 import pure_pcapy
 import time
 import sys
+import argparse
 
 from random import randint
 
@@ -22,8 +23,8 @@ class Prompt:
         return (await self.q.get()).rstrip('\n')
 
 
-async def steal(device):
-    s = await util.setup(device, baudrate=57600)
+async def steal(device, baudrate=57600):
+    s = await util.setup(device, baudrate)
     eui64 = await getattr(s, 'getEui64')()
     eui64 = bellows.types.named.EmberEUI64(*eui64)
 
@@ -119,8 +120,13 @@ async def steal(device):
 
     s.close()
 
-if len(sys.argv) != 2:
+parser = argparse.ArgumentParser(description='Set device and optional baudrate')
+parser.add_argument('device', type=str, help='Device path, e.g., /dev/ttyUSB0')
+parser.add_argument('-b', '--baudrate', type=int, default=57600, help='Baud rate (default: 57600)')
+args = parser.parse_args()
+
+if not args.device:
     print("syntax:", sys.argv[0], "/dev/ttyUSB0")
     sys.exit(1)
 
-asyncio.get_event_loop().run_until_complete(steal(sys.argv[1]))
+asyncio.get_event_loop().run_until_complete(steal(args.device, args.baudrate))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bellows==0.16.0
+bellows==bellows-0.35.2
 


### PR DESCRIPTION
This PR closes the [skyconnect issue](https://github.com/vanviegen/hue-thief/issues/20#issue-1667827971) and adds more versatility for other baud rates.  While retaining all existing functionality.

Thanks again for making this tool! I had tons of Hue Bulbs that refused to pair with Home Assistant until using this tool! 👍