### PR TITLE
Fix pcap dump when frame is a LVBytes object

### DIFF
--- a/hue-thief.py
+++ b/hue-thief.py
@@ -42,7 +42,9 @@ async def steal(device_path, baudrate, scan_channel):
         ts_sec = int(ts)
         ts_usec = int((ts - ts_sec) * 1000000)
         hdr = pure_pcapy.Pkthdr(ts_sec, ts_usec, len(frame), len(frame))
-        pcap.dump(hdr, frame)
+
+        # In some instances the frame will be a type zigpy.types.basic.LVBytes
+        pcap.dump(hdr, bytes(frame))
 
 
     def handle_incoming(frame_name, response):


### PR DESCRIPTION
Some frames come back as LVBytes [^1]. This is a subtype of `bytes` so we can just cast it. Without the cast the pcap.dump will error with `pure_pcapy.PcapError: can dump only bytes`.

Fixes https://github.com/vanviegen/hue-thief/issues/30

[^1]: https://github.com/zigpy/zigpy/blob/038d57b9430ebc9e0f9c1c106440f7d27161f4e7/zigpy/types/basic.py#L718