### PR TITLE
Fix deprecated close method

### DIFF
--- a/hue-thief.py
+++ b/hue-thief.py
@@ -124,7 +124,7 @@ async def steal(device_path, baudrate, scan_channel):
 
     await dev.mfglibEnd()
 
-    dev.close()
+    await dev.disconnect()
 
 
 parser = argparse.ArgumentParser(description='Factory reset a Hue light bulb.')


### PR DESCRIPTION

Fix:
```
Traceback (most recent call last):
  File "//hue-thief.py", line 136, in <module>
    asyncio.get_event_loop().run_until_complete(steal(args.device, args.baudrate, args.channel))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 721, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "//hue-thief.py", line 127, in steal
    dev.close()
    ^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bellows/ezsp/__init__.py", line 271, in __getattr__
    return getattr(self._protocol, name)
  File "/usr/local/lib/python3.13/site-packages/bellows/ezsp/protocol.py", line 205, in __getattr__
    raise AttributeError(f"{name} not found in COMMANDS")
AttributeError: close not found in COMMANDS
^CException ignored on threading shutdown:
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/threading.py", line 1534, in _shutdown
    atexit_call()
  File "/usr/local/lib/python3.13/threading.py", line 1505, in <lambda>
    _threading_atexits.append(lambda: func(*arg, **kwargs))
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 31, in _python_exit
    t.join()
  File "/usr/local/lib/python3.13/threading.py", line 1092, in join
    self._handle.join(timeout)
```

* [`hue-thief.py`](diffhunk://#diff-5fd038830c5a7324c38a7e74ce70c17519879ac7cf0826860e77ea1d8c929997L127-R127): Modified the `handle_incoming` function to use `await dev.disconnect()` becase `dev.close()` is deprecated.